### PR TITLE
Create zh_cn

### DIFF
--- a/Common/src/main/resources/assets/abitmorehex/lang/zh_cn.flatten.json5
+++ b/Common/src/main/resources/assets/abitmorehex/lang/zh_cn.flatten.json5
@@ -1,0 +1,182 @@
+{
+  "item.abitmorehex": {
+    "librarians_lens": "图书管理员的透镜",
+    "stitched_scribbles": "拼起的杂录",
+    "ancient_parchment": "远古羊皮纸",
+    "ancient_parchment.written": "定稿远古羊皮纸",
+    "akashic_wood_circlet": "阿卡夏饰冠",
+    "staff": {
+      "miku": "初音法杖"
+    },
+  },
+  "emi.category.abitmorehex.rooted_table_item": "融合合成",
+  "block.abitmorehex": {
+    "rooted_table_block": "融合祭坛",
+    "soul_jar": "束魂玻璃罐",
+    "empty_jar": "玻璃罐"
+  },
+  "hexcasting": {
+    "action": {
+      "abitmorehex:evokegraspingvines": "唤出擒困藤",
+      "abitmorehex:evokeleechingvines": "唤出汲血藤",
+      "abitmorehex:activateroottable": "激活融合祭坛",
+      "abitmorehex:chargealtar": "融合祭坛充能",
+      "abitmorehex:randomizelist": "意识蒙雾",
+      "abitmorehex:thoughtclutter": "思维混杂",
+      "abitmorehex:containerpos": "容器之精思",
+      "abitmorehex:infusioncrafting": "融合合成",
+      "abitmorehex:whiletrueloop": "西西弗斯之策略",
+      "abitmorehex:indexdict": "宪章之策略",
+      "abitmorehex:appenddict": "层叠之馏化",
+      "abitmorehex:adddict": "合表之馏化",
+      "abitmorehex:getindexdict": "定位器之馏化",
+      "abitmorehex:getkeys": "钥匙大师之提整",
+      "abitmorehex:emptydict": "空章之精思",
+      "abitmorehex:minorteleport": "次等传送",
+      "abitmorehex:mediafyitem": "媒质化",
+      "abitmorehex:weaveitem": "构筑",
+      "abitmorehex:castitemspell": "自动机之策略",
+      "abitmorehex:castitemwithspell": "技师之策略",
+      "abitmorehex:getitemslot": "仓库管理员之策略",
+      "abitmorehex:throwitem": "仓库管理员之抛投",
+      "abitmorehex:switchitem": "组织者之策略",
+      "abitmorehex:readcurrentsubiota": "誊抄员之精思",
+      "abitmorehex:writecurrentsubiota": "誊抄员之策略",
+      "abitmorehex:translocation": "换位",
+
+      "abitmorehex:readsubiota": "密码学家之精思",
+      "abitmorehex:writesubiota": "密码学家之策略",
+
+      "abitmorehex:head/write": "制帽匠之策略",
+      "abitmorehex:head/read": "制帽匠之精思",
+      "abitmorehex:head/writeable": "制帽匠之校验",
+      "abitmorehex:head/readable": "制帽匠之考察",
+
+      "abitmorehex:chest/write": "束腰匠之策略",
+      "abitmorehex:chest/read": "束腰匠之精思",
+      "abitmorehex:chest/writeable": "束腰匠之校验",
+      "abitmorehex:chest/readable": "束腰匠之考察",
+
+      "abitmorehex:legs/write": "胫甲匠之策略",
+      "abitmorehex:legs/read": "胫甲匠之精思",
+      "abitmorehex:legs/writeable": "胫甲匠之校验",
+      "abitmorehex:legs/readable": "胫甲匠之考察",
+
+      "abitmorehex:feet/write": "制鞋匠之策略",
+      "abitmorehex:feet/read": "制鞋匠之精思",
+      "abitmorehex:feet/writeable": "制鞋匠之校验",
+      "abitmorehex:feet/readable": "制鞋匠之考察",
+
+
+      "book": {
+        "abitmorehex:thoughtclear": "思维理顺",
+      }
+    },
+    "category": {
+      "collection_of_casters.desc": "来自多位法师的法术"
+    }
+  },
+  "abitmorehex": {
+    "entry": {
+      "viraels_spells": "§pVirael的法术",
+      "spirael_list": "§pSpirael的列表操作",
+      "willow_insights": "§pWillow的洞察",
+      "infusion_altar_spells": "§p融合祭坛法术",
+      "infusion_altar_use": "§p融合祭坛的使用"
+    },
+    "page": {
+      "viraels_spells": {
+
+      }
+    },
+    "category": {
+      "reading_writing": "抽象读写",
+      "collection_of_casters": "法师辑录",
+      "collection_of_casters.desc": "记有各式各样的图案、工具、法师等。",
+      "spells": "法术",
+      "itemcasting": "物品施法",
+      "itemcasting.desc": "物品施法是依托于物品的施法方式。可以视作某种工程技艺。",
+      "spells.desc": "本节中汇总了来自多位法师的法术。收集这些法术的渠道不一，而且人们大多认为它们并不如那些古代的大作重要。",
+      "infusion_spells": "融合祭坛法术",
+      "infusion_spells.desc": "本节中记录了使用融合祭坛所需的操作、法术和配方。融合祭坛是可供各位法师使用的工具，可定制性高；在媒质领域（咒术师）之外也可以使用。"
+    },
+    "book": {
+      "patterns": {
+        "itemcasting": {
+          "eval": "运行",
+          "rw": "读写"
+        },
+        "itemcasting.eval": {
+          "switchitem": "接受两个数作为槽位，而后互换两槽位的内容物。消耗大约 1/10 个紫水晶粉。",
+          "throwitem": "丢出当前物品栏内所给槽位中的物品堆叠。",
+          "getitemslot": "返回当前施法物品的槽位。",
+          "castitemwithspell": "让给定槽位中的物品以所给 iota 列表施法。",
+          "castitem": "让给定槽位中的物品以其自身 iota 施法。",
+          "intro": "后页图案可以通过物品的访问位置操控它们周围的媒质。它们可以派上很大用场，尤其是在配合能自主施法的事物运作时。"
+        },
+        "itemcasting.rw": {
+        "intro": "后页图案可让物品读写其自身的副 iota。$(#7777ff)$(italic)有些特别……",
+          "write": "将所给 iota 写入其自身副 iota。",
+          "read": "读取并返回其自身的副 iota。"
+        },
+        "spells": {
+          "glacio_practical": "实用图案",
+          "unstable": "不稳定法术",
+          "willows_spells": "Willow的法术",
+          "mediafy": "解编",
+          "reading_writing":  "杂项读写",
+          "general": {
+            "containerpos": "这个法术相当独特，而且在文献中被提及了很多次。它会返回施法方块的位置，或施法物品所处的位置。"
+          }
+            },
+          "spells.willows_spells": {
+            "evokeleechingvines": "给予不断造成伤害的效果，和凋零效果类似。不过和让生命力凋零不同的是，这个法术会释放生命力（也许能在其他地方用到）。",
+            "evokeleechingvines_cost": "将持续时间乘以 1.2，而后再乘上效果强度，最后整体求平方，即可得到消耗量。",
+            "evokegraspingvines": "给予一个效果，基本相当于困住目标。若目标移动，此效果即会造成伤害并令其缓慢。",
+            "evokegraspingvines_cost": "将持续时间乘以 0.2，而后再乘上效果强度，最后整体求平方，即可得到消耗量。"
+          },
+        "spells.mediafy": {
+          "weave": "在所给物质向量处编结一个物品实体。",
+          "mediafy": "接受一个物品实体，将其$(#7777ff)解编入$()局部媒质，而后返回媒质化的物品。",
+          "intro2": "媒质并不是静止的，它是环境中存在的能量。我给物质的转化定了如下几个术语：转化成媒质是$(#7777ff)解编()，而转化成固体物质是$(#7777ff)编结()。我设计了后页的图案，以将物品转化成抽象的能量，或是反向进行转化。",
+          "intro": "媒质是另一种形态的物质，因此固体物质可以转化成媒质。这种物质通常会结成丝线。虽然我无法加以运用，但一位法师同行——$(#228822)Willow$()——指出，它们需要一个参考点，就好像植物有根系一样。所有媒质都有参考点，参考点则维持了媒质的规整。"
+        },
+        "spells.glacio_practical": {
+          "whiletrueloop": "运行一个图案列表，若模拟得到的栈顶部有 True，则再次施放该图案列表。",
+          "indexdict": "移除两个 iota，返回使用第一个 iota 为键、第二个 iota 为值的字典。",
+          "appenddict": "移除一个字典和两个 iota，将两 iota 组成的键值对（第一个为键，第二个为值）加入字典，而后返回处理后的字典。",
+          "emptydict": "压入一个空字典。",
+          "adddict": "移除两个字典，返回两者各元素合并得到的字典。",
+          "getindexdict": "移除一个字典和一个 iota，而后以该 iota 为键，返回字典中对应的值。",
+          "getkeys": "移除一个字典，返回包含所有键的列表。"
+        },
+        "spells.unstable": {
+          "translocation": "按照第二个向量的偏移量移动第一个向量处的方块。偏移量越大，或所给数越小，引入的随机性就越多。",
+          "intro": "自然已经从我身上$(l:hexcasting:basics/start_to_see)支取$()了许多代价，我的感知能力因而超脱常人。后页的所有法术都很强大，但要是不逼一逼自然，就都很难预测效果。$(br)别让它反过来伤害你。$(#661166)你才是主人$()，它不是。",
+          "minorteleport": "根据所给 vec3 传送目标实体。偏移量越大，或所给数越小，引入的随机性就越多。"
+        },
+        "spells.reading_writing": {
+          "intro": "后页记载了与装备和其他抽象 iota 存储设备有关的读写法术。",
+          "headread": "读取我头部槽物品中的主 iota 并返回。",
+          "chestread": "读取我上身槽物品中的主 iota 并返回。",
+          "legsread": "读取我下身槽物品中的主 iota 并返回。",
+          "feetread": "读取我足部槽物品中的主 iota 并返回。",
+          "headwrite": "移除栈顶 iota，将其写入头部槽物品。",
+          "chestwrite": "移除栈顶 iota，将其写入上身槽物品。",
+          "legswrite": "移除栈顶 iota，将其写入下身槽物品。",
+          "feetwrite": "移除栈顶 iota，将其写入足部槽物品。",
+          "headwable": "返回一个布尔值。若头部槽物品可写，则返回 True；否则返回 False。",
+          "chestwable": "返回一个布尔值。若上身槽物品可写，则返回 True；否则返回 False。",
+          "legswable": "返回一个布尔值。若下身槽物品可写，则返回 True；否则返回 False。",
+          "feetwable": "返回一个布尔值。若足部槽物品可写，则返回 True；否则返回 False。",
+          "headrable": "返回一个布尔值。若头部槽物品可读，则返回 True；否则返回 False。",
+          "chestrable": "返回一个布尔值。若上身槽物品可读，则返回 True；否则返回 False。",
+          "legsrable": "返回一个布尔值。若下身槽物品可读，则返回 True；否则返回 False。",
+          "feetrable": "返回一个布尔值。若足部槽物品可读，则返回 True；否则返回 False。",
+          "writesubiota": "移除栈顶 iota，将其作为副 iota 写入另一只手中的物品。",
+          "readsubiota": "读取另一只手中物品的副 iota 并返回。"
+        }
+      }
+    }
+  }
+}

--- a/doc/resources/assets/abitmorehex/lang/zh_cn.flatten.json5
+++ b/doc/resources/assets/abitmorehex/lang/zh_cn.flatten.json5
@@ -1,0 +1,8 @@
+{
+  hexdoc: {
+    abitmorehex: {
+      title: "ABitMoreHex: Recasted之书",
+      description: "咒法学的ABitMoreHex: Recasted附属",
+    },
+  }
+}


### PR DESCRIPTION
The current translations haven't cover the lines written as-is in `patchouli_books`.
Translations could be done with a separate `zh_cn` in the same directory as `en_us`, but this would involve page structure inconsistency when `zh_cn` goes outdated.

I'm not quite sure if `patchouli_books` would be using localization keys eventually, but would be doing separate directories if needed.